### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This is a simple MCP server that sends emails using Resend's API. Why? Now you can let Cursor or Claude Desktop compose emails for you and send it right away without having to copy and paste the email content.
 
+<a href="https://glama.ai/mcp/servers/55pe0fq14l">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/55pe0fq14l/badge" alt="Email Sending MCP server" />
+</a>
+
 Built with:
 
 - [Resend](https://resend.com/)


### PR DESCRIPTION
This PR adds a badge for the [Email Sending MCP](https://glama.ai/mcp/servers/55pe0fq14l) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/55pe0fq14l">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/55pe0fq14l/badge" alt="Email Sending MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.